### PR TITLE
fix the predicate for remove a terminated case.

### DIFF
--- a/case_labelling/case_labelling.ipynb
+++ b/case_labelling/case_labelling.ipynb
@@ -193,7 +193,7 @@
         "        else:\n",
         "            case_sequence.append(max_prob_case_id)\n",
         "            last_symbols_open_cases[max_prob_case_id] = symbol\n",
-        "            if matrix[last_symbol][CONST_END] == max(matrix[last_symbol]):\n",
+        "            if matrix[symbol][CONST_END] == max({matrix[symbol][s] for s in matrix.keys()}):\n",
         "                last_symbols_open_cases.pop(max_prob_case_id, None)\n",
         "\n",
         "    case_sequence.append(-1)\n",


### PR DESCRIPTION
The original predicate uses last_symbol as the key of the matrix, which is a temporary variable used in the iteration of last_symbols_open_cases. Besides, comparing a string with a float is always false.